### PR TITLE
Add workaround documentation for numeric network identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Group commands deal with reading and manipulating consensus logs. Currently only
 
 There is also a `config` command, which allows you to view and change some configuration details:
 
+**usage note**
+
+If the ledger name has a numeric network name (e.g 12345/ledger1), you need to add quotes around it: `"12345/ledger1"`.
+
 ### config
 
 


### PR DESCRIPTION
cli4clj wraps clojure.main/repl. The clojure `read` function tries to parse numeric
network identies as numbers, and fails:

> 12345/abc
Invalid number

The read function isn't pluggable in cli4clj, so I've filed a bug.
https://github.com/ruedigergad/cli4clj/issues/4

In the meantime, adding documentation of the workaround, which prevents the reader from
trying to parse the input as a number.

FC-1297