### PR TITLE
Update cli4clj dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ Group commands deal with reading and manipulating consensus logs. Currently only
 
 There is also a `config` command, which allows you to view and change some configuration details:
 
-**usage note**
-
-If the ledger name has a numeric network name (e.g 12345/ledger1), you need to add quotes around it: `"12345/ledger1"`.
-
 ### config
 
 

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [cheshire "5.10.0"]
                  [com.fluree/raft "1.0.0-beta1"]
                  [com.fluree/crypto "0.3.5" :exclusions [org.clojure/clojurescript]]
-                 [cli4clj "1.7.6" :exclusions [org.clojure/core.async]]
+                 [cli4clj "1.7.10" :exclusions [org.clojure/core.async]]
                  [clj-figlet "0.1.1"]
                  [com.damballa/abracad "0.4.13"]]
   :main fluree.core


### PR DESCRIPTION
This brings in a bugfix so that invalid EDN can be used as input in the prompt.

ex. `ledger remember 1234/abc` now works correctly instead of throwing an "Invalid
number" exception.

We can remove the workaround documented in the README.

CLI-6